### PR TITLE
Removed unnecessary project

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,6 @@ On-Demand Assessment names differ per product. To export from the assessment you
     search *
     | where $table contains "Assessment"
     | summarize by $table
-    | project $table
     ```
     
 1.	Select **Run** to get the assessment name. 


### PR DESCRIPTION
Hi Inge,

The **project** command seems a bit unnecessary beacuse the **summarize** will only return **$table** so you might want to remove the **project $table** part to perhaps keep it a bit more simple.

Please feel free to ignore/disregard! :)

Warm regards,
Serge.